### PR TITLE
Include "-chia" in GIT_COMMIT_HASH to identify the fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ execute_process(
   OUTPUT_VARIABLE GIT_COMMIT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
+add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}-chia\"")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release"


### PR DESCRIPTION
GIT_COMMIT_HASH appears in a few places, including the version string, so this helps distinguish the Chia fork vs the original madMAx repo.

We could have just --version append "-chia", but the other places that emit GIT_COMMIT_HASH would miss out.